### PR TITLE
docs: refresh command count 52,031 → 69,854 on docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Multivendor Network CLI Tools — 52,031 commands · 17 vendors · one page</title>
-<meta name="description" content="A zero-dependency single-file HTML reference for network engineers: 52,031 CLI commands across 17 vendors and tools, searchable, comparable, deep-linkable, with vendor-correct automation snippet generation. Served statically by GitHub Pages.">
+<title>Multivendor Network CLI Tools — 69,854 commands · 17 vendors · one page</title>
+<meta name="description" content="A zero-dependency single-file HTML reference for network engineers: 69,854 CLI commands across 17 vendors and tools, searchable, comparable, deep-linkable, with vendor-correct automation snippet generation. Served statically by GitHub Pages.">
 <meta name="color-scheme" content="dark">
 <style>
   :root{
@@ -253,7 +253,7 @@
       <!-- inlined docs/assets/hero.svg -->
       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-labelledby="heroTitle heroDesc" fill="none" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
         <title id="heroTitle">multivendor-cli-configurator — architecture</title>
-        <desc id="heroDesc">Animated terminal banner: a phosphor-green prompt types a network command while 17 vendor chips light up in sequence, connector lines pulse from the command to each matched vendor, a stream of grayed commands scrolls behind, and a counter ticks toward 52,031 commands.</desc>
+        <desc id="heroDesc">Animated terminal banner: a phosphor-green prompt types a network command while 17 vendor chips light up in sequence, connector lines pulse from the command to each matched vendor, a stream of grayed commands scrolls behind, and a counter ticks toward 69,854 commands.</desc>
         <defs>
           <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
             <stop offset="0" stop-color="#0b0f0a"/>
@@ -368,7 +368,7 @@
           <rect class="cursor" x="298" y="96" width="9" height="16" fill="#39ff14"/>
           <text x="66" y="138" font-size="11" fill="#8b9a8e"># one intent &#8594; 17 vendor syntaxes, concept-aligned</text>
           <text x="66" y="170" font-size="12" fill="#8b9a8e">corpus</text>
-          <text x="116" y="170" font-size="13" font-weight="700" fill="#39ff14" filter="url(#glow)">52,031 commands</text>
+          <text x="116" y="170" font-size="13" font-weight="700" fill="#39ff14" filter="url(#glow)">69,854 commands</text>
           <text x="290" y="170" font-size="11" fill="#5eead4">cache-then-revalidate</text>
         </g>
         <g stroke-width="1.6" fill="none">
@@ -382,7 +382,7 @@
               font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif">multivendor-cli-configurator</text>
         <path class="underline" d="M616 134 H1118" stroke="#39ff14" stroke-width="2.5" stroke-linecap="round"/>
         <text x="616" y="162" font-size="16" fill="#8b9a8e"
-              font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif">52,000+ CLI commands &#183; 17 vendors &#183; one zero-dependency HTML file</text>
+              font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif">69,000+ CLI commands &#183; 17 vendors &#183; one zero-dependency HTML file</text>
         <g font-size="11" font-weight="600" text-anchor="middle">
           <g class="node"><rect class="chipBox d0"  x="44"  y="234" width="84" height="26" rx="13" fill="#0f1814" stroke="#2a3a30" stroke-width="1.4"/><text class="chipLbl d0"  x="86"  y="251" fill="#8b9a8e">Cisco</text></g>
           <g class="node"><rect class="chipBox d1"  x="136" y="234" width="84" height="26" rx="13" fill="#0f1814" stroke="#2a3a30" stroke-width="1.4"/><text class="chipLbl d1"  x="178" y="251" fill="#8b9a8e">Juniper</text></g>
@@ -430,10 +430,10 @@
     </div>
 
     <h1 class="hero-title">Multivendor Network CLI Tools</h1>
-    <p class="tagline"><b>52,000+ CLI commands</b> across 17 vendors and tools in one searchable, comparable, deep-linkable single-file page.</p>
+    <p class="tagline"><b>69,000+ CLI commands</b> across 17 vendors and tools in one searchable, comparable, deep-linkable single-file page.</p>
 
     <div class="chips" role="list" aria-label="Key statistics">
-      <div class="chip" role="listitem"><div class="num" data-count="52031">0</div><div class="lbl">CLI commands</div></div>
+      <div class="chip" role="listitem"><div class="num" data-count="69854">0</div><div class="lbl">CLI commands</div></div>
       <div class="chip" role="listitem"><div class="num" data-count="17">0</div><div class="lbl">vendors &amp; tools</div></div>
       <div class="chip" role="listitem"><div class="num" data-count="3">0</div><div class="lbl">view modes</div></div>
       <div class="chip" role="listitem"><div class="num" data-count="870">0</div><div class="lbl">FRR rows verified live</div></div>
@@ -452,7 +452,7 @@
     <h2 class="title" id="overview-h">One page, every vendor's syntax</h2>
     <div class="overview-grid">
       <div class="panel reveal">
-        <p class="lede">Multivendor Network CLI Tools is a zero-dependency, single-file HTML reference for network engineers that puts <strong style="color:var(--green)">52,031 CLI commands</strong> across 17 vendors and tools into one searchable, filterable, deep-linkable browser page.</p>
+        <p class="lede">Multivendor Network CLI Tools is a zero-dependency, single-file HTML reference for network engineers that puts <strong style="color:var(--green)">69,854 CLI commands</strong> across 17 vendors and tools into one searchable, filterable, deep-linkable browser page.</p>
         <p class="lede" style="margin-top:1rem">It solves the everyday pain of juggling per-vendor syntax — letting engineers search, compare commands concept-aligned side by side, and generate vendor-correct automation snippets (NETCONF, ncclient, Netmiko, Ansible, Bash) pre-filled from their own command values.</p>
         <p class="lede" style="margin-top:1rem">An offline, stdlib-only Python pipeline turns published vendor docs — and a live 10-node Docker FRR lab — into one deduped <code style="font-family:var(--mono);color:var(--teal)">commands.json</code> that GitHub Pages serves statically. No backend, no build, no JS dependencies.</p>
       </div>
@@ -461,8 +461,8 @@
         <div class="mini"><span class="k">CONCEPT_SYNONYMS entries</span><span class="v">37</span></div>
         <div class="mini"><span class="k">YANG automation patterns</span><span class="v">15</span></div>
         <div class="mini"><span class="k">FRR lab nodes (Docker)</span><span class="v">10</span></div>
-        <div class="mini"><span class="k">commands.json size</span><span class="v">~17 MB</span></div>
-        <div class="mini"><span class="k">Roles: router / switch / firewall</span><span class="v">25,270 / 22,625 / 4,136</span></div>
+        <div class="mini"><span class="k">commands.json size</span><span class="v">~18 MB</span></div>
+        <div class="mini"><span class="k">Roles: router / switch / firewall</span><span class="v">43,055 / 22,656 / 4,143</span></div>
       </div>
     </div>
   </section>
@@ -473,7 +473,7 @@
     <h2 class="title" id="features-h">Key features</h2>
     <p class="lede">Search, compare, and automate across 17 CLIs — all from one static file.</p>
     <div class="grid" style="margin-top:1.4rem">
-      <article class="card reveal"><span class="ic" aria-hidden="true">📚</span><h3>52,031 commands, 17 vendors, one page</h3><p>Arista EOS, Cisco IOS/IOS-XE/ASA/NX-OS, Juniper Junos, FRR, VyOS, Huawei VRP, Aruba AOS-CX, Extreme EXOS, FortiOS, PAN-OS, Mikrotik RouterOS, NVIDIA Cumulus NVUE, Nokia SR Linux, SONiC, plus Microsoft PowerShell, Linux iproute2, and Wireshark tshark — all searchable in a single static HTML file.</p></article>
+      <article class="card reveal"><span class="ic" aria-hidden="true">📚</span><h3>69,854 commands, 17 vendors, one page</h3><p>Arista EOS, Cisco IOS/IOS-XE/ASA/NX-OS, Juniper Junos, FRR, VyOS, Huawei VRP, Aruba AOS-CX, Extreme EXOS, FortiOS, PAN-OS, Mikrotik RouterOS, NVIDIA Cumulus NVUE, Nokia SR Linux, SONiC, plus Microsoft PowerShell, Linux iproute2, and Wireshark tshark — all searchable in a single static HTML file.</p></article>
       <article class="card reveal"><span class="ic" aria-hidden="true">🪟</span><h3>Three view modes</h3><p>Cards (auto-fit grid grouped by category), Table (sortable, exportable to CSV/Markdown/JSON/TXT), and Compare — a concept-aligned, N-vendor-aware matrix that lines up Cisco's neighbor row with Junos's peer row, paginated and virtualized for the full corpus.</p></article>
       <article class="card reveal"><span class="ic" aria-hidden="true">🔧</span><h3>Automate drawer (YANG + SSH)</h3><p>Regex-extracts your IP/VLAN/ASN/interface from a command and renders vendor-correct NETCONF XML, ncclient Python, Netmiko, NAPALM, and Ansible tasks pre-filled with your values across 15 model-driven patterns, with a universal SSH fallback for every command.</p></article>
       <article class="card reveal"><span class="ic" aria-hidden="true">🔐</span><h3>Secret mode for snippets</h3><p>Toggle how snippets read credentials — Inline (demo only), .env via python-dotenv (default, safer pasteboard), or OS keyring — and every snippet re-renders in place with a matching .env.example / keyring set one-liner.</p></article>
@@ -498,7 +498,7 @@
     lab["10-node Docker FRR Lab - live capture"]:::source
     subgraph SYS["multivendor-cli-configurator"]
       app["index.html - single-file web app"]:::core
-      data["commands.json - 52,031 records"]:::store
+      data["commands.json - 69,854 records"]:::store
       pipe["scripts Python ETL - parse, merge, clean"]:::build
     end
     pages["GitHub Pages - static host, auto-deploy"]:::ext
@@ -531,7 +531,7 @@
       compare["Compare + Concept Align - conceptKey, lookupConcept, CONCEPT_SYNONYMS 37"]:::accent
       auto["Automation Generators - Netmiko, Ansible, NETCONF, Bash"]:::amber
     end
-    json[("commands.json - 52,031 rows")]:::store
+    json[("commands.json - 69,854 rows")]:::store
     persist[["IndexedDB + localStorage - ?ws= base64 deep-link"]]:::ext
     json --> boot --> state
     state --> filter --> state
@@ -564,7 +564,7 @@
     inter["per-source JSON - encor.json, junos.json, frr.json"]:::build
     master["parse.py + merge_dcn_corpus.py - merge + dedupe by normalized cmd"]:::accent
     clean["clean_titles.py + audit_data_quality.py - repair, quarantine"]:::accent
-    out[("commands.json - 52,031 records")]:::store
+    out[("commands.json - 69,854 records")]:::store
     web["index.html - fetch at boot"]:::core
     src --> parsers --> inter --> master --> clean --> out --> web
     classDef source fill:#475569,stroke:#94a3b8,color:#f8fafc
@@ -591,7 +591,7 @@
     alt changed or no cache
         CDN-->>B: new ETag + length
         B->>CDN: GET commands.json (no-store)
-        CDN-->>B: 52,031 records
+        CDN-->>B: 69,854 records
         B->>IDB: idbPut corpus + ETag
         B->>B: bootRender, badge fresh
     else unchanged
@@ -632,7 +632,7 @@
         <thead><tr><th scope="col">Module</th><th scope="col">Responsibility</th></tr></thead>
         <tbody>
           <tr><td><span class="mod">index.html</span><span class="te">Vanilla JS · HTML · CSS · Fetch · IndexedDB · localStorage</span></td><td>The entire single-file client app (~5,827 lines of vanilla JS): boot/cache loader, global DATA state + render dispatcher, filter/deep-link engine, concept-aligned Compare engine, and automation snippet generators. No framework, no build.</td></tr>
-          <tr><td><span class="mod">commands.json</span><span class="te">Static JSON ~17 MB · GitHub Pages</span></td><td>Single source of truth — flat array of 52,031 command records across 17 vendors/tools. Fetched once at boot (cache-then-revalidate) and queried entirely client-side. FRR rows carry optional live/in_docs provenance flags.</td></tr>
+          <tr><td><span class="mod">commands.json</span><span class="te">Static JSON ~18 MB · GitHub Pages</span></td><td>Single source of truth — flat array of 69,854 command records across 17 vendors/tools. Fetched once at boot (cache-then-revalidate) and queried entirely client-side. FRR rows carry optional live/in_docs provenance flags.</td></tr>
           <tr><td><span class="mod">scripts/parse.py</span><span class="te">Python 3 stdlib</span></td><td>Master merger — generic markdown walker that folds in community sources, seed entries, and all per-source JSONs, deduping globally by normalized cmd to emit commands.json.</td></tr>
           <tr><td><span class="mod">scripts/parse_frr.py</span><span class="te">Python 3 stdlib</span></td><td>Parses the FRR Master CLI reference JSON (docs ∪ Docker-FRR live scrape) into frr.json, mapping daemons to categories and tagging each row with live/in_docs provenance flags surfaced as a green "live" badge in the UI.</td></tr>
           <tr><td><span class="mod">scripts/merge_dcn_corpus.py</span><span class="te">Python 3 stdlib (argparse, json, re, pathlib)</span></td><td>Merges the DCN tool's pre-built cli-export.json corpus into commands.json, normalizing vendor labels and roles and deduping by (vendor, normalized cmd) so existing FRR provenance flags survive. Added Microsoft/Linux/Wireshark surfaces.</td></tr>
@@ -689,7 +689,7 @@
   <div class="foot-grid">
     <div>
       <div class="brand" style="margin-bottom:.5rem"><span class="dot" aria-hidden="true"></span><b>multivendor-cli</b></div>
-      <p style="margin:0; max-width:42ch; font-size:.9rem; color:var(--muted-dim)">52,031 CLI commands across 17 vendors and tools in one searchable, comparable, deep-linkable single-file page.</p>
+      <p style="margin:0; max-width:42ch; font-size:.9rem; color:var(--muted-dim)">69,854 CLI commands across 17 vendors and tools in one searchable, comparable, deep-linkable single-file page.</p>
     </div>
     <nav class="foot-links" aria-label="Footer links">
       <a href="https://github.com/gesh75/multivendor-cli-configurator" target="_blank" rel="noopener">GitHub repo ↗</a>


### PR DESCRIPTION
## Summary

The `docs/` landing page (https://gesh75.github.io/multivendor-cli-configurator/docs/) was still frozen at the old corpus size while the repo now ships 69,854 commands. Synced every derived figure to the current `commands.json` (authoritative counts cross-checked against `README.md`):

- **52,031 → 69,854 CLI commands** — 12 occurrences: `<title>`, meta description, hero SVG banner + `<desc>`, the count-up stat chip (`data-count`), overview lede, features card heading, the system-context / component / data-flow mermaid diagrams, the components table, and the footer.
- **52,000+ → 69,000+** in the two rounded taglines.
- **Role breakdown 25,270 / 22,625 / 4,136 → 43,055 / 22,656 / 4,143** (router / switch / firewall — sums to 69,854, matches README).
- **commands.json size ~17 MB → ~18 MB** (actual file is 18.4 MB).

Vendor count (17), the 10-node FRR lab, 870 live-verified FRR rows, 37 CONCEPT_SYNONYMS, and 15 YANG patterns were all verified against the data/README and are unchanged. HTML parses cleanly; no residual stale numbers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF)_

## Summary by Sourcery

Refresh docs landing page statistics to reflect the expanded commands corpus and updated commands.json size.

Documentation:
- Update all occurrences of the total CLI command count on the docs index page from 52,031 to 69,854, including hero text, taglines, metadata, diagrams, tables, and footer.
- Adjust rounded command-count taglines and commands.json size to ~18 MB and refresh the router/switch/firewall role breakdown figures to match the current corpus.