### PR TITLE
ci: add commands.json consistency gate + fix stale docs footer figures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  consistency:
+    name: Docs match commands.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Check docs are in sync with the corpus
+        run: python3 scripts/check_consistency.py

--- a/docs/index.html
+++ b/docs/index.html
@@ -457,7 +457,7 @@
         <p class="lede" style="margin-top:1rem">An offline, stdlib-only Python pipeline turns published vendor docs — and a live 10-node Docker FRR lab — into one deduped <code style="font-family:var(--mono);color:var(--teal)">commands.json</code> that GitHub Pages serves statically. No backend, no build, no JS dependencies.</p>
       </div>
       <div class="mini-stats reveal" aria-label="Corpus breakdown">
-        <div class="mini"><span class="k">index.html (vanilla JS lines)</span><span class="v">5,827</span></div>
+        <div class="mini"><span class="k">index.html (vanilla JS lines)</span><span class="v">5,861</span></div>
         <div class="mini"><span class="k">CONCEPT_SYNONYMS entries</span><span class="v">37</span></div>
         <div class="mini"><span class="k">YANG automation patterns</span><span class="v">15</span></div>
         <div class="mini"><span class="k">FRR lab nodes (Docker)</span><span class="v">10</span></div>
@@ -631,7 +631,7 @@
       <table>
         <thead><tr><th scope="col">Module</th><th scope="col">Responsibility</th></tr></thead>
         <tbody>
-          <tr><td><span class="mod">index.html</span><span class="te">Vanilla JS · HTML · CSS · Fetch · IndexedDB · localStorage</span></td><td>The entire single-file client app (~5,827 lines of vanilla JS): boot/cache loader, global DATA state + render dispatcher, filter/deep-link engine, concept-aligned Compare engine, and automation snippet generators. No framework, no build.</td></tr>
+          <tr><td><span class="mod">index.html</span><span class="te">Vanilla JS · HTML · CSS · Fetch · IndexedDB · localStorage</span></td><td>The entire single-file client app (~5,861 lines of vanilla JS): boot/cache loader, global DATA state + render dispatcher, filter/deep-link engine, concept-aligned Compare engine, and automation snippet generators. No framework, no build.</td></tr>
           <tr><td><span class="mod">commands.json</span><span class="te">Static JSON ~18 MB · GitHub Pages</span></td><td>Single source of truth — flat array of 69,854 command records across 17 vendors/tools. Fetched once at boot (cache-then-revalidate) and queried entirely client-side. FRR rows carry optional live/in_docs provenance flags.</td></tr>
           <tr><td><span class="mod">scripts/parse.py</span><span class="te">Python 3 stdlib</span></td><td>Master merger — generic markdown walker that folds in community sources, seed entries, and all per-source JSONs, deduping globally by normalized cmd to emit commands.json.</td></tr>
           <tr><td><span class="mod">scripts/parse_frr.py</span><span class="te">Python 3 stdlib</span></td><td>Parses the FRR Master CLI reference JSON (docs ∪ Docker-FRR live scrape) into frr.json, mapping daemons to categories and tagging each row with live/in_docs provenance flags surfaced as a green "live" badge in the UI.</td></tr>
@@ -695,7 +695,7 @@
       <a href="https://github.com/gesh75/multivendor-cli-configurator" target="_blank" rel="noopener">GitHub repo ↗</a>
       <a href="https://gesh75.github.io/multivendor-cli-configurator/" target="_blank" rel="noopener">Live demo ↗</a>
       <a href="#hero">Back to top ↑</a>
-      <span style="color:var(--muted-dim)">License: not specified</span>
+      <span style="color:var(--muted-dim)">License: MIT</span>
     </nav>
   </div>
   <p class="foot-note">Auto-generated documentation · single self-contained page · dark-neon terminal theme. All figures traced to README.md, docs/ARCHITECTURE.md, and commands.json.</p>

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Fail if the docs have drifted from the real corpus in commands.json.
+
+The command count, per-role breakdown, and vendor count are repeated by hand
+across README.md and docs/index.html. This checker recomputes them from the
+single source of truth (commands.json) and asserts every derived figure still
+appears verbatim in those files, so a stale number fails CI instead of shipping.
+
+Design notes:
+- Hard failures are the raw numeric facts (total count, per-role counts, vendor
+  count) — these are what actually drift and each is matched as a substring, so
+  surrounding wording can change freely without tripping CI.
+- The rounded marketing form (e.g. "69,000+") and the ~MB size are advisory
+  warnings only, since those are phrasing/rounding choices that flip on small
+  changes and shouldn't gate a merge.
+
+Stdlib only. Run from anywhere: `python3 scripts/check_consistency.py`.
+Exit 0 = consistent, 1 = drift found (details printed), 2 = usage/IO error.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CORPUS = ROOT / "commands.json"
+
+# Files that restate corpus figures. All get the same hard numeric checks.
+TRACKED = ("README.md", "docs/index.html")
+
+
+def fmt(n: int) -> str:
+    return f"{n:,}"
+
+
+def rounded_thousands(n: int) -> str:
+    return f"{(n // 1000) * 1000:,}+"
+
+
+def main() -> int:
+    if not CORPUS.exists():
+        print(f"ERROR: {CORPUS} not found", file=sys.stderr)
+        return 2
+    try:
+        data = json.loads(CORPUS.read_text())
+    except (ValueError, OSError) as exc:
+        print(f"ERROR: cannot read {CORPUS}: {exc}", file=sys.stderr)
+        return 2
+
+    total = len(data)
+    roles = Counter(row.get("role", "?") for row in data)
+    vendors = sorted({row.get("vendor", "?") for row in data})
+    size_mb = round(CORPUS.stat().st_size / (1024 * 1024))
+
+    print("Corpus (source of truth: commands.json)")
+    print(f"  total commands : {fmt(total)}")
+    print(f"  rounded form   : {rounded_thousands(total)}")
+    print("  roles          : " + " · ".join(f"{r} {fmt(c)}" for r, c in roles.most_common()))
+    print(f"  vendors        : {len(vendors)}")
+    print(f"  size           : ~{size_mb} MB")
+    print()
+
+    # Read each tracked file exactly once.
+    contents: dict[str, str | None] = {}
+    for rel in TRACKED:
+        path = ROOT / rel
+        contents[rel] = path.read_text() if path.exists() else None
+
+    # Hard requirements: the raw numeric facts must appear verbatim.
+    required = [fmt(total)] + [fmt(c) for c in roles.values()] + [f"{len(vendors)} vendor"]
+
+    failures: list[str] = []
+    for rel, text in contents.items():
+        if text is None:
+            failures.append(f"{rel}: file missing")
+            continue
+        for value in required:
+            if value not in text:
+                failures.append(f"{rel}: missing {value!r}")
+
+    # Advisory only — phrasing/rounding, not raw facts.
+    for rel, text in contents.items():
+        if text is None:
+            continue
+        if rounded_thousands(total) not in text:
+            print(f"WARNING: {rel} does not contain rounded form "
+                  f"{rounded_thousands(total)!r}")
+    docs = contents.get("docs/index.html")
+    if docs is not None and f"~{size_mb} MB" not in docs:
+        print(f"WARNING: docs/index.html does not mention '~{size_mb} MB' "
+              f"(commands.json is now ~{size_mb} MB)")
+
+    if failures:
+        print("\nDRIFT DETECTED — docs are out of sync with commands.json:\n")
+        for f in failures:
+            print(f"  ✗ {f}")
+        print("\nUpdate the file(s) above (and the profile hub) to the corpus figures.")
+        return 1
+
+    print("OK — README.md and docs/index.html match commands.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stops the doc-drift that left the landing page frozen at the old 52,031 count, and fixes two more stale figures found in the same audit.

**New: consistency gate (`scripts/check_consistency.py` + `.github/workflows/ci.yml`)**
- Recomputes the command count, per-role split (router/switch/firewall), and vendor count from `commands.json` — the single source of truth — and asserts every figure still appears verbatim in `README.md` and `docs/index.html`. Drift → non-zero exit with a precise list of what's stale where.
- Stdlib-only, matching the repo's existing `scripts/` convention. Runs on push + PR.
- Verified both ways: passes on the current tree, and a negative test (breaking one number) fails with `✗ docs/index.html: missing total command count '69,854'`.

**Docs footer fixes (`docs/index.html`)**
- `License: not specified` → `License: MIT` — the repo ships an MIT `LICENSE`, so the page was understating it.
- `5,827 lines` → `5,861` (current `index.html` line count), 2 spots.

## Notes
- The existing Node stress suite (`tests/stress_test.js`) is **not** gated in CI here: it has a pre-existing perf-threshold failure — `T6 lookupConcept ~2.9s` vs a `<1.8s` target — that the larger corpus now exceeds. That deserves its own fix (optimize `lookupConcept`, or raise the threshold) rather than shipping a red CI on arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF)_

## Summary by Sourcery

Add a CI gate to ensure documentation statistics stay in sync with commands.json and refresh stale corpus and license figures in the landing page.

New Features:
- Introduce a Python-based consistency checker that validates documented command, role, and vendor counts against commands.json.
- Add a GitHub Actions workflow that runs the consistency checker on pushes and pull requests to main.

Enhancements:
- Update docs/index.html to reflect the current command corpus size and per-role breakdown, including the rounded headline counts.
- Refresh the documented commands.json approximate size and index.html line count to match the current corpus and codebase.
- Correct the published license in the docs footer from unspecified to MIT to align with the repository license file.