### PR TITLE
perf: optimize lookupConcept (2894ms → 633ms) and gate stress suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,14 @@ jobs:
           python-version: "3.x"
       - name: Check docs are in sync with the corpus
         run: python3 scripts/check_consistency.py
+
+  stress-test:
+    name: Node stress + correctness suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run tests/stress_test.js
+        run: node tests/stress_test.js

--- a/index.html
+++ b/index.html
@@ -4823,16 +4823,29 @@ const CONCEPT_SYNONYMS = [
 
 function lookupConcept(haystack){
   if(!haystack) return null;
+  // The synonym needles are constants, so lowercase them once and cache the
+  // result on the function — a full-corpus pass calls this ~70K times, and
+  // hoisting toLowerCase out of the inner loop turns each call into pure
+  // substring checks. Behavior-identical to matching CONCEPT_SYNONYMS directly.
+  let table = lookupConcept._lc;
+  if(!table){
+    table = lookupConcept._lc = CONCEPT_SYNONYMS.map(c => ({
+      concept: c.concept, cat: c.cat,
+      any: c.any.map(alt => Array.isArray(alt)
+        ? alt.map(s => s.toLowerCase())
+        : alt.toLowerCase()),
+    }));
+  }
   const h = haystack.toLowerCase();
-  for(const c of CONCEPT_SYNONYMS){
+  for(const c of table){
     for(const alt of c.any){
-      if(Array.isArray(alt)){
+      if(typeof alt === "string"){
+        if(h.includes(alt)) return { concept: c.concept, cat: c.cat };
+      } else {
         // All substrings must be present (AND)
         let ok = true;
-        for(const s of alt){ if(!h.includes(s.toLowerCase())){ ok = false; break; } }
+        for(const s of alt){ if(!h.includes(s)){ ok = false; break; } }
         if(ok) return { concept: c.concept, cat: c.cat };
-      } else {
-        if(h.includes(alt.toLowerCase())) return { concept: c.concept, cat: c.cat };
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes the pre-existing `T6` stress-test failure and promotes the suite to a real CI gate.

**The problem:** `lookupConcept` called `.toLowerCase()` on every `CONCEPT_SYNONYMS` needle on every invocation. A full-corpus pass calls it ~70K times across ~60 concept entries and their substrings, so the same constant strings were re-lowercased billions of times — `T6 lookupConcept × full corpus` ran ~2.9s against an `<1.8s` target on the grown 69,854-row corpus.

**The fix:** lowercase the needles once and cache the table on the function object (`lookupConcept._lc`), built lazily on first call. Each call is then pure substring matching. The change is fully self-contained within the `lookupConcept` body (the stress test extracts that function by regex into a sandbox, so no new top-level symbol is introduced), and it's **behavior-identical** — concept correctness stays **10/10**.

```
T6 lookupConcept × full corpus: 2894ms → 633ms   (target <1800ms)   ✅
```

**CI:** with the suite now fully green, `tests/stress_test.js` is wired into the workflow as a second job alongside the consistency check — previously omitted precisely because T6 was red. The stress suite (whole run) passes locally with ALL TESTS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoNS6C16GXRmcooVTXbERF)_

## Summary by Sourcery

Optimize concept lookup performance and enable the Node stress test suite as a gated CI job.

Bug Fixes:
- Resolve the failing T6 stress-test case by improving lookupConcept handling of concept synonym matching.

Enhancements:
- Cache lowercased concept synonym needles within lookupConcept to significantly reduce repeated string processing during corpus scans.

CI:
- Add a dedicated Node-based stress and correctness test job to the CI workflow and wire it to run tests/stress_test.js.

Tests:
- Promote the stress_test.js suite to an automated CI gate once all scenarios pass.