### PR TITLE
Unblock live site: lean GitHub Actions Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stage public site only
+        run: |
+          mkdir -p _site
+          # App + corpus
+          cp -a index.html commands.json configurator.html favicon.svg \
+                og-image.png manifest.webmanifest robots.txt sitemap.xml \
+                LICENSE README.md ARCHITECTURE.md .nojekyll _site/
+          # Docs landing + assets
+          cp -a docs _site/docs
+          # Browser stress harness (optional)
+          mkdir -p _site/tests
+          cp -a tests/stress_test.html tests/stress_test.js tests/STRESS_TEST.md \
+                tests/stress_test_results.json _site/tests/
+          # Keep artifact lean — do not publish scripts/*.json sources
+          du -sh _site
+          find _site -type f | wc -l
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

https://gesh75.github.io/multivendor-cli-configurator/ is still on the **2026-07-13** build (69,854 cmds).

- **#5/#6**: Pages failed (Jekyll choking on Ansible `{{ }}` in `index.html`)
- **#7** (`.nojekyll`): **build succeeds**, but **deploy times out** (~10 min stuck in `deployment_in_progress`) while publishing the full-repo artifact

## This PR

Adds `.github/workflows/pages.yml` that publishes a lean `_site/` (app + docs + tests only — **skips `scripts/*.json` sources**).

## Required one-time setting (I cannot change it via API — 403)

In the repo: **Settings → Pages → Build and deployment → Source → GitHub Actions**

After that, this workflow deploys on every `main` push and the live site should update to **70,006** commands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-471fc54e-cd5c-4df9-b447-4813702f064a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-471fc54e-cd5c-4df9-b447-4813702f064a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Build:
- Add a GitHub Actions Pages workflow that stages a minimal _site directory and uploads it as the deployable artifact for GitHub Pages.