### PR TITLE
chore: gap scan + improvement plan

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -1,0 +1,164 @@
+# Gap analysis
+
+Verifiable scan of `gesh75/multivendor-cli-configurator` at `a57fd5a`
+(plus the three small fixes in this PR). Ranked by blast radius, not
+ambition. Out of scope: corpus growth, dependency upgrades, Studio
+rewrites, new product features.
+
+## Method (what was proved)
+
+| Check | Result |
+|---|---|
+| `python3 scripts/check_consistency.py` | totals / roles / `17 vendor` match `commands.json` (70,006) |
+| `python3 scripts/audit_data_quality.py` | 0 cmd-prose, 0 title-prose, 0 over-long titles |
+| `python3 scripts/deep_gap_dig.py` | 0 critical; 945 empty `desc`; OS/cat/Automate floors hold |
+| Corpus integrity (`commands.json`) | 17 vendors, 21 OS labels, 0 empty required fields except `desc`, 0 duplicate `(vendor, cmd)` |
+| `.github/workflows/ci.yml` | only `check_consistency.py` + `tests/stress_test.js` |
+| Grep of Automate `ncclient` templates | one invalid Python connect line (fixed here) |
+| `tests/` vs public surfaces | Node suite extracts from `index.html` only; `studio.html` untested |
+
+What was **not** run (skipped on purpose): full `parse.py` regen (needs
+gitignored `scripts/sources/` + fill order; documented foot-gun),
+browser IDB harness (`tests/stress_test.html`), live FRR lab capture,
+secret scanners beyond repo grep, dependency upgrades.
+
+---
+
+## P0 — fix or gate now
+
+### P0-1 · Automate OSPF snippet is invalid Python
+
+- **File:** `index.html` (AUTO_OSPF → Cisco → `ncclient`, ~line 2067)
+- **Evidence:** the template literal is
+  `port=port=830,,` — SyntaxError if pasted. Neighbor templates on the
+  same page use `port=830,`. No test extracted or parsed Automate
+  snippets, so CI was green.
+- **Fix in this PR:** correct the connect args; add a Node assertion
+  that `index.html` does not contain `port=port=` or `,\s*,` in
+  `manager.connect(...)` lines.
+
+### P0-2 · CLI Studio has no automated test
+
+- **Files:** `studio.html`, `studio-data.json`, `tests/stress_test.js`
+- **Evidence:** `tests/stress_test.js` only `readFileSync`s `index.html`
+  + `commands.json`. Grep of `tests/` for `studio` is empty. Studio is
+  a shipped Pages surface (`pages.yml` copies both files; sitemap
+  priority 0.9).
+- **Not fixed here** (would be a new harness, not a one-line safe
+  patch). Recommended next job below.
+
+---
+
+## P1 — next agent / small follow-ups
+
+### P1-1 · README vendor + category table drifted; CI did not see it
+
+- **Files:** `README.md` lines 80–101; `scripts/check_consistency.py`
+- **Evidence (pre-fix):** `commands.json` vs README
+
+  | Field | README (was) | `commands.json` |
+  |---|---:|---:|
+  | Cisco | 22,145 | 22,168 |
+  | Extreme | 2,790 | 2,800 |
+  | Nokia | 1,125 | 1,131 |
+  | Interfaces | 17,490 | 16,941 |
+  | Protocols | 10,173 | 10,150 |
+  | System | 7,815 | 7,705 |
+  | Troubleshooting | 6,513 | 6,501 |
+  | Security | 4,369 | 4,370 |
+  | VLAN | 4,208 | 4,084 |
+  | Routing | 2,806 | 2,793 |
+  | BGP | 2,153 | 2,155 |
+  | OSPF | 1,604 | 1,606 |
+  | VXLAN | 255 | 257 |
+  | EVPN | 498 | 499 |
+
+  `docs/DEVELOP.md` already names this: the checker “only checks total /
+  roles / vendor-count phrase.” Totals still matched, so CI passed.
+- **Fix in this PR:** sync the README figures; gate per-vendor and
+  top-10 + VXLAN/EVPN counts in `check_consistency.py` for `README.md`
+  only (`docs/index.html` does not restated those cells).
+
+### P1-2 · Quality scripts exist but are not CI jobs
+
+- **Files:** `.github/workflows/ci.yml`; `scripts/deep_gap_dig.py`;
+  `scripts/audit_data_quality.py`
+- **Evidence:** CI YAML has two jobs. `ARCHITECTURE.md` / `docs/DEVELOP.md`
+  list `deep_gap_dig.py` as a regen gate. `audit_data_quality.py`
+  **always exits 0** even if it finds prose (report-only). The Node
+  suite already duplicates most deep-gap floors, so this is coverage
+  duplication, not a current red check.
+
+### P1-3 · CHANGELOG claims an AEGIS pre-change gate Studio does not have
+
+- **Files:** `CHANGELOG.md` (“AEGIS-style pre-change (risk, blast,
+  rollback) · Harden tab”); `studio.html` `runLint()` / `TITLES.lint`
+- **Evidence:** `runLint()` is seven regex heuristics (NTP / AAA / SSH /
+  syslog / BGP / BFD / secret). No blast-radius or rollback UI. The
+  lint lede itself says “Heuristic lint before AEGIS”.
+
+### P1-4 · Studio vendor labels diverge from the 70k corpus
+
+- **File:** `studio-data.json`
+- **Evidence:** Studio vendors include `Fortinet` (6) and `Palo Alto`
+  (5). Corpus labels are `FortiOS` and `PAN-OS`. Migrate / coverage
+  therefore cannot align those rows with cheatsheet filters.
+
+### P1-5 · Studio Migrate “Copy” copies the diff, not the target CLI
+
+- **File:** `studio.html` `runMigrate()` + `bindCards()`
+- **Evidence:** the button sets `data-copy="${esc(body)}"` but
+  `bindCards` copies `pre.cli.textContent`, which is the unified diff.
+
+### P1-6 · `parse_extras.py` hard-codes a laptop path
+
+- **File:** `scripts/parse_extras.py` `DEFAULT_DOCS`
+- **Evidence:** default is
+  `/Users/georgigaydarov/02_Projects/Network_Automation/.../06_Documentation`.
+  Overridable via `CLI_WORK_DOCS` / `--source`, but a cold clone fails
+  closed with a username in-tree.
+
+### P1-7 · `parse.py` last without fill scripts shrinks the corpus
+
+- **Files:** `scripts/parse.py` (writes `commands.json`); `docs/DEVELOP.md`
+  pitfall #2
+- **Evidence:** `parse.py` rebuilds from intermediates and does not
+  apply `parse_modern.py` / `expand_thin_vendors.py` /
+  `fix_coverage_gaps.py`. Running it alone is a foot-gun; no CI job
+  regenerates, so this is DX, not a live break.
+
+---
+
+## P2 — later / delete or ignore
+
+| Gap | Evidence | Bias |
+|---|---|---|
+| Duplicate `ARCHITECTURE.md` vs `docs/ARCHITECTURE.md` | `diff` is empty; image `docs/img/architecture.svg` is correct from repo root, **broken** from `docs/` (would resolve `docs/docs/img/...`) | delete one or symlink; fix the docs-relative image |
+| `tests/STRESS_TEST.md` still says **52,313** rows (2026-05-27) | file header + vendor table (Cisco 4,551) vs live 70,006 / Cisco 22,168 | rewrite from `stress_test_results.json` or delete the frozen table |
+| `tests/stress_test.js` comments say “29,509-row corpus” | line 3 | comment-only |
+| Legacy `configurator.html` still in Pages artifact | `pages.yml` `cp` list; README says “not linked from the live site” | drop from `_site/` (keep in git) |
+| 945 empty `desc` | `deep_gap_dig.py` warning | fill later; do not block |
+| Studio Netmiko `device_type` only special-cases junos / eos / nxos | `studio.html` `snippets()` else `cisco_ios` | map from `OS_DEV_TYPE` or drop the claim |
+| No offline service worker for Studio | `CHANGELOG.md` “Still open” | skip unless someone asks |
+| Thin SONiC (459) / SR OS (72) | floors pass; CHANGELOG already tracks | corpus work, not this scan |
+
+---
+
+## Fixes in this PR (≤3, all safe)
+
+1. Repair `AUTO_OSPF` Cisco `ncclient` connect args in `index.html`.
+2. Gate snippet syntax in `tests/stress_test.js` so P0-1 cannot regress.
+3. Sync README vendor/category figures and extend
+   `check_consistency.py` so that table cannot drift again.
+
+No drive-by refactors. No `parse.py` regen. `configurator.html` left
+alone (archive).
+
+---
+
+## Recommended next agent job
+
+Add a Node smoke harness that loads `studio-data.json` (schema + vendor
+label parity with `commands.json`) and extracts `lookupConcept` /
+`runLint` / migrate-copy from `studio.html` — do not grow the 70k
+corpus.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ vendors and host/tool surfaces are tagged in the **Type** column.
 
 | Vendor / Tool | OS / Surface | Type | Commands |
 |---|---|---|---|
-| **Cisco** | IOS / IOS-XE (full **Master Command List**) · ASA 9.24 · NX-OS | Network | 22,145 |
+| **Cisco** | IOS / IOS-XE (full **Master Command List**) · ASA 9.24 · NX-OS | Network | 22,168 |
 | **Arista** | EOS | Network | 7,397 |
 | **VyOS** | VyOS (full config tree) | Network | 6,289 |
 | **Huawei** | VRP (bracketed prompts, iStack, Eth-Trunk, OSPF/BGP) | Network | 4,425 |
@@ -85,20 +85,20 @@ vendors and host/tool surfaces are tagged in the **Type** column.
 | **FRR** | FRRouting (vtysh) — docs **+ verified live on a 10-node Docker FRR lab** | Network | 3,949 |
 | **Microsoft** | Windows PowerShell networking cmdlets | Host OS | 3,352 |
 | **Juniper** | Junos (MX / EX / QFX / SRX) | Network | 3,217 |
-| **Extreme** | EXOS (VLAN-centric, STP, OSPF, SummitStacking, MLAG, ACLs) | Network | 2,790 |
+| **Extreme** | EXOS (VLAN-centric, STP, OSPF, SummitStacking, MLAG, ACLs) | Network | 2,800 |
 | **Linux** | `ip` / `iproute2` / host networking | Host OS | 2,592 |
 | **FortiOS** | Fortinet (`config / set / end` blocks, REST cmdb) | Network | 2,383 |
 | **Wireshark** | `tshark` capture + display filters | Tool | 2,130 |
 | **PAN-OS** | Palo Alto firewalls (`set rulebase security ...`, virtual routers) | Network | 1,224 |
 | **Mikrotik** | RouterOS (`/path` syntax, firewall filters, queues) | Network | 1,216 |
 | **NVIDIA** | Cumulus Linux 5.x with NVUE (`nv set/show`) | Network | 1,168 |
-| **Nokia** | SR Linux (declarative) **+ SR OS** (`os=sros`, classic CLI) | Network | 1,125 |
+| **Nokia** | SR Linux (declarative) **+ SR OS** (`os=sros`, classic CLI) | Network | 1,131 |
 | **SONiC** | OCP / Azure SONiC (Click CLI, `show ip ...`) | Network | 459 |
 | | | **TOTAL (17)** | **70,006** |
 
-By category (top 10): Interfaces 17,490 · Protocols 10,173 · System 7,815 ·
-Troubleshooting 6,513 · Security 4,369 · VLAN 4,208 · Routing 2,806 ·
-BGP 2,153 · Misc 2,018 · OSPF 1,604. Dedicated **VXLAN** (255) and **EVPN** (498) categories added.
+By category (top 10): Interfaces 16,941 · Protocols 10,150 · System 7,705 ·
+Troubleshooting 6,501 · Security 4,370 · VLAN 4,084 · Routing 2,793 ·
+BGP 2,155 · Misc 2,018 · OSPF 1,606. Dedicated **VXLAN** (257) and **EVPN** (499) categories added.
 
 Modern-ops coverage (new): Telemetry (gNMI/gRPC/NETCONF/RESTCONF) ·
 Automation (on-box Python/eAPI/JSON-RPC) · Provisioning (ZTP/PnP/POAP) ·

--- a/index.html
+++ b/index.html
@@ -2064,7 +2064,7 @@ const AUTO_OSPF = {
 </config>`,
     ncclient: `# OSPF process ${v.pid}, network ${v.net} ${v.wild} area ${v.area}
 from ncclient import manager
-m = manager.connect(host=${pyArg('host')}, port=port=830,, username=${pyArg('user')}, password=${pyArg('pass')},
+m = manager.connect(host=${pyArg('host')}, port=830, username=${pyArg('user')}, password=${pyArg('pass')},
                     hostkey_verify=False, device_params={"name":"iosxe"})
 m.edit_config(target="running", config=open("ospf.xml").read())`,
     ansible: `- name: OSPF process ${v.pid}

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -10,6 +10,8 @@ Design notes:
 - Hard failures are the raw numeric facts (total count, per-role counts, vendor
   count) — these are what actually drift and each is matched as a substring, so
   surrounding wording can change freely without tripping CI.
+- README.md also restates per-vendor and top-category counts in a table that
+  already drifted once; those figures are gated for README only.
 - The rounded marketing form (e.g. "69,000+") and the ~MB size are advisory
   warnings only, since those are phrasing/rounding choices that flip on small
   changes and shouldn't gate a merge.
@@ -51,7 +53,9 @@ def main() -> int:
 
     total = len(data)
     roles = Counter(row.get("role", "?") for row in data)
-    vendors = sorted({row.get("vendor", "?") for row in data})
+    vendor_counts = Counter(row.get("vendor", "?") for row in data)
+    cat_counts = Counter(row.get("cat") or "?" for row in data)
+    vendors = sorted(vendor_counts)
     size_mb = round(CORPUS.stat().st_size / (1024 * 1024))
 
     print("Corpus (source of truth: commands.json)")
@@ -79,6 +83,19 @@ def main() -> int:
         for value in required:
             if value not in text:
                 failures.append(f"{rel}: missing {value!r}")
+
+    # README-only: the coverage table is the thing that actually drifted.
+    readme = contents.get("README.md")
+    if readme:
+        for vendor, n in vendor_counts.most_common():
+            if fmt(n) not in readme:
+                failures.append(f"README.md: missing {vendor} count {fmt(n)!r}")
+        for cat, n in cat_counts.most_common(10):
+            if fmt(n) not in readme:
+                failures.append(f"README.md: missing category count {cat} {fmt(n)!r}")
+        for cat in ("VXLAN", "EVPN"):
+            if fmt(cat_counts[cat]) not in readme:
+                failures.append(f"README.md: missing category count {cat} {fmt(cat_counts[cat])!r}")
 
     # Advisory only — phrasing/rounding, not raw facts.
     for rel, text in contents.items():

--- a/tests/stress_test.js
+++ b/tests/stress_test.js
@@ -337,6 +337,17 @@ results['T6b_concept_correctness'] = `${conceptOK}/${conceptCases.length}`;
     }
   }
 
+  // Generated ncclient snippets must be parseable Python (P0-1: port=port=830,,)
+  const connectLines = html.split('\n').filter(l => /manager\.connect\(/.test(l));
+  const badConnect = connectLines.filter(l => /port=port=/.test(l) || /,\s*,/.test(l));
+  if (badConnect.length) {
+    gapFails++;
+    console.log(`   SNIPPET SYNTAX MISS: ${badConnect.length} manager.connect line(s)`);
+    badConnect.slice(0, 3).forEach(l => console.log(`     ${l.trim()}`));
+  } else {
+    console.log(`   Automate connect snippets: ${connectLines.length} lines, no port=port= / double-comma`);
+  }
+
   // No silent Cisco YANG fallback in AUTO renderers
   const badFb = (html.match(/\|\|AUTO_\w+\.Cisco\)\(v\)/g) || []).length;
   if (badFb) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Verifiable gap scan of the static multivendor CLI configurator. Full ranked list: [`GAP_ANALYSIS.md`](./GAP_ANALYSIS.md).

Three small safe fixes only — no corpus regen, no Studio rewrite, no dependency upgrades.

## Fixes

1. **P0-1** — `index.html` AUTO_OSPF Cisco `ncclient` emitted `port=port=830,,` (invalid Python). Repaired to `port=830,`.
2. **P0-1 gate** — `tests/stress_test.js` now fails if any `manager.connect(` line contains `port=port=` or a double comma.
3. **P1-1** — README vendor/category table had drifted (Cisco 22,145→22,168, Extreme 2,790→2,800, Nokia 1,125→1,131, plus top-10 / VXLAN / EVPN). `check_consistency.py` now asserts those README figures against `commands.json`.

## What I proved

- Corpus is 70,006 rows / 17 vendors / 21 OS labels; 0 cmd-prose; 0 duplicate `(vendor, cmd)`; `deep_gap_dig.py` critical = 0.
- Existing CI (`check_consistency.py` + `tests/stress_test.js`) was green on totals/roles while the README **vendor table** and one Automate snippet were wrong.
- CLI Studio (`studio.html` + `studio-data.json`) is a shipped Pages surface with **zero** Node tests.
- After the fixes: `check_consistency.py` exit 0; `ast.parse` of the repaired two-line `manager.connect` succeeds; the old `port=port=830,,` token is a `SyntaxError`; `node tests/stress_test.js` → **ALL TESTS PASSED** (including `Automate connect snippets: 32 lines, no port=port= / double-comma`).

## What I skipped

- Full `parse.py` regen (needs gitignored sources + fill order; documented foot-gun).
- Browser IDB harness (`tests/stress_test.html`).
- Deleting `configurator.html` / duplicate `ARCHITECTURE.md`.
- Growing SONiC / SR OS.
- Wiring `deep_gap_dig.py` as its own CI job (Node suite already covers the floors).

## Next recommended agent job

Add a Node smoke harness that loads `studio-data.json` (schema + vendor-label parity with `commands.json`) and extracts `lookupConcept` / `runLint` / migrate-copy from `studio.html` — do not grow the 70k corpus.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6761be04-c350-4710-852f-63437fc87210?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6761be04-c350-4710-852f-63437fc87210&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Audit the configurator for verifiable coverage gaps, fix the malformed Cisco OSPF snippet, and prevent README coverage data from drifting.

Bug Fixes:
- Correct the invalid Cisco OSPF ncclient connection snippet in the generated configurator output.
- Add regression coverage to reject malformed manager.connect arguments in Automate snippets.

Enhancements:
- Synchronize README vendor and category coverage figures with the command corpus and enforce those figures through consistency checks.
- Document the repository’s verified coverage gaps, test coverage limitations, and recommended follow-up work.

Documentation:
- Add a ranked gap analysis covering corpus integrity, tooling, CI coverage, Studio limitations, and follow-up recommendations.
- Update README coverage tables with current vendor and category counts.

Tests:
- Extend the stress test suite to detect duplicated port arguments and double commas in generated connection snippets.