### PR TITLE
chore: gap scan + improvement plan

### DIFF
--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -65,30 +65,36 @@ No other P0 found: `deep_gap_dig.py` is green, no secret files / API keys,
 
 ## P1 — next (small, evidence-backed)
 
-1. **`tests/STRESS_TEST.md` is a 52,313-row report.** Header, vendor table,
+1. **Buildkite PR check fails with no in-repo pipeline.**
+   `buildkite/multivendor-cli-configurator` failed this PR in ~2s
+   (build #15) and also failed merged PR #13; `main` build #11 passed.
+   There is no `.buildkite/` / `pipeline.yml` in the repo. GitHub Actions
+   `ci.yml` is the real gate and is green on this branch. Either add a
+   checked-in pipeline or drop the required Buildkite context on pull_request.
+2. **`tests/STRESS_TEST.md` is a 52,313-row report.** Header, vendor table,
    and timings predate the 70,006 corpus. `tests/stress_test_results.json`
    was later refreshed; the markdown was not. Misleading for anyone
    reproducing CI.
-2. **`scripts/deep_gap_dig.py` is not a CI job.** `.github/workflows/ci.yml`
+3. **`scripts/deep_gap_dig.py` is not a CI job.** `.github/workflows/ci.yml`
    runs `check_consistency.py` + `tests/stress_test.js` only. The Node suite
    already duplicates most floors, so this is a second gate, not a hole —
    wire it only if you want a Python-only path.
-3. **945 empty `desc` fields** (`deep_gap_dig.py` warning): VyOS 742, FRR 170,
+4. **945 empty `desc` fields** (`deep_gap_dig.py` warning): VyOS 742, FRR 170,
    Cisco 29, SONiC 4. Not quarantined (cmd/title are intact). Fill or
    generate from `title` if Studio/cheatsheet empty-state bothers you.
-4. **`scripts/parse.py` will silently rewrite `commands.json`** from
+5. **`scripts/parse.py` will silently rewrite `commands.json`** from
    intermediates and **drop** DCN / modern-ops / thin-vendor fills if those
    passes are skipped (`docs/DEVELOP.md` pitfall #2). No
    `--dry-run` / refuse-if-shrink guard. Smallest fix: refuse to write if
    `len(cmds)` is below the current file’s length unless `--force`.
-5. **`scripts/merge_dcn_corpus.py` defaults `CLI_WORK_DCN_CORPUS` to a
+6. **`scripts/merge_dcn_corpus.py` defaults `CLI_WORK_DCN_CORPUS` to a
    personal `~/02_Projects/Network_Automation/...` path.** Fine as an
    override, confusing as a default. Point the default at
    `scripts/sources/` (gitignored) or require `--source`.
-6. **Category / overlay counts are still unguarded.** This PR synced the
+7. **Category / overlay counts are still unguarded.** This PR synced the
    README one-liner; `check_consistency.py` does not pin
    `Interfaces 16,941` etc. Add only if the line keeps drifting.
-7. **SONiC (459) and classic SR OS (72) stay at the floor.** Known product
+8. **SONiC (459) and classic SR OS (72) stay at the floor.** Known product
    gap (`CHANGELOG.md` / `docs/DEVELOP.md`). Out of scope here.
 
 ## P2 — later / laziness

--- a/GAP_ANALYSIS.md
+++ b/GAP_ANALYSIS.md
@@ -1,0 +1,141 @@
+# Gap analysis + improvement plan
+
+Verifiable scan of `gesh75/multivendor-cli-configurator` on
+`cursor/gap-scan-multivendor-cli-configurator-d2db` (base `main` @ `a57fd5a`).
+Stdlib Python + Node only. No corpus rewrite. No dependency upgrades.
+
+## Method (what was proved)
+
+| Check | Command | Result |
+|---|---|---|
+| Docs ↔ corpus totals/roles | `python3 scripts/check_consistency.py` | **pass** (totals). Vendor **table** was stale — see P0-2. |
+| Data-quality audit | `python3 scripts/audit_data_quality.py` | **pass** (0 cmd-prose / title-prose / long titles) |
+| Coverage floors | `python3 scripts/deep_gap_dig.py` | **pass** (0 critical). Advisory: 945 empty `desc`. |
+| Script compile | `python3 -m compileall scripts` | **pass** |
+| Node stress + correctness | `node tests/stress_test.js` | run after the three fixes below |
+| Vendor/cat recount | `Counter` over `commands.json` (70,006 rows) | README table + category line drifted |
+
+`commands.json` is internally consistent: 17 vendors, 21 OS labels, 0 empty
+`title`/`cmd`, 0 duplicate `(vendor, cmd)` pairs, 0 missing required keys.
+
+## P0 — fix now (file + evidence)
+
+### P0-1 · Broken Automate snippet (correctness) — **fixed in this PR**
+
+- **File:** `index.html` (Cisco `AUTO_OSPF` `ncclient` template, was line 2067)
+- **Evidence:** generated Python was
+  `manager.connect(host=..., port=port=830,, username=...)`.
+  That is a `SyntaxError` if a user copies the Automate drawer. Sibling
+  templates (e.g. `AUTO_STATIC` at line 1955) omit `port` and do not double
+  the comma. No existing test scanned snippet source.
+- **Fix:** drop the broken `port=port=830,,` fragment; add a smoke check in
+  `tests/stress_test.js` that fails on `port=port`, `,,`, or `==` inside
+  `manager.connect(` lines.
+
+### P0-2 · README vendor table drifted off `commands.json` (docs + missing gate) — **fixed in this PR**
+
+- **File:** `README.md` (vendor table, lines 80–97) vs `commands.json`
+- **Evidence:** `check_consistency.py` only asserted the **total** `70,006`,
+  role counts, and the phrase `17 vendor`. `docs/DEVELOP.md` already called
+  this out as an unguarded pitfall. Recount:
+
+  | Vendor | README claimed | Corpus |
+  |---|---:|---:|
+  | Cisco | 22,145 | **22,168** (+23) |
+  | Extreme | 2,790 | **2,800** (+10) |
+  | Nokia | 1,125 | **1,131** (+6) |
+  | *(table sum)* | 69,967 | **70,006** |
+
+  Category one-liner was also stale (Interfaces 17,490 vs **16,941**, etc.).
+- **Fix:** rewrite the three vendor cells and the top-10 category line from
+  the live corpus. `check_consistency.py` now regex-matches each
+  `| **Vendor** | … | N |` row in README.
+
+### P0-3 · User-facing hero banner still said 52,031 (docs) — **fixed in this PR**
+
+- **File:** `docs/assets/hero.svg` (README + docs landing banner)
+- **Evidence:** `<desc>` and the on-art counter still read `52,031 commands`
+  while `docs/index.html` (same illustration, inlined) and every gated
+  figure say `70,006`. `check_consistency.py` does not read SVG.
+- **Fix:** `52,031` → `70,006` in the two strings. No new gate (SVG
+  phrasing is advisory, same as the rounded `70,000+` form).
+
+No other P0 found: `deep_gap_dig.py` is green, no secret files / API keys,
+`.nojekyll` is present, Pages inventory files all exist.
+
+## P1 — next (small, evidence-backed)
+
+1. **`tests/STRESS_TEST.md` is a 52,313-row report.** Header, vendor table,
+   and timings predate the 70,006 corpus. `tests/stress_test_results.json`
+   was later refreshed; the markdown was not. Misleading for anyone
+   reproducing CI.
+2. **`scripts/deep_gap_dig.py` is not a CI job.** `.github/workflows/ci.yml`
+   runs `check_consistency.py` + `tests/stress_test.js` only. The Node suite
+   already duplicates most floors, so this is a second gate, not a hole —
+   wire it only if you want a Python-only path.
+3. **945 empty `desc` fields** (`deep_gap_dig.py` warning): VyOS 742, FRR 170,
+   Cisco 29, SONiC 4. Not quarantined (cmd/title are intact). Fill or
+   generate from `title` if Studio/cheatsheet empty-state bothers you.
+4. **`scripts/parse.py` will silently rewrite `commands.json`** from
+   intermediates and **drop** DCN / modern-ops / thin-vendor fills if those
+   passes are skipped (`docs/DEVELOP.md` pitfall #2). No
+   `--dry-run` / refuse-if-shrink guard. Smallest fix: refuse to write if
+   `len(cmds)` is below the current file’s length unless `--force`.
+5. **`scripts/merge_dcn_corpus.py` defaults `CLI_WORK_DCN_CORPUS` to a
+   personal `~/02_Projects/Network_Automation/...` path.** Fine as an
+   override, confusing as a default. Point the default at
+   `scripts/sources/` (gitignored) or require `--source`.
+6. **Category / overlay counts are still unguarded.** This PR synced the
+   README one-liner; `check_consistency.py` does not pin
+   `Interfaces 16,941` etc. Add only if the line keeps drifting.
+7. **SONiC (459) and classic SR OS (72) stay at the floor.** Known product
+   gap (`CHANGELOG.md` / `docs/DEVELOP.md`). Out of scope here.
+
+## P2 — later / laziness
+
+- **Duplicate architecture docs:** root `ARCHITECTURE.md` and
+  `docs/ARCHITECTURE.md` are byte-identical (134 lines). Pages copies the
+  root file; README links `docs/ARCHITECTURE.md`. Pick one.
+- **`configurator.html` still ships in the Pages artifact**
+  (`.github/workflows/pages.yml`) while README says it is archive-only and
+  unlinked. Drop it from `_site/` or leave it.
+- **`.gitignore` still lists `demo/node_modules/`, `demo/package*.json`,
+  `demo/page@*.webm`** — the `demo/` tree is gone.
+- **Stress-test labels still say “29.5K rows”** (`tests/stress_test.js`
+  T3 name). Cosmetic.
+- **`hostkey_verify=False` in every ncclient snippet** — demo-only, but
+  easy to paste onto a real box. A one-line comment already exists in
+  places; not a secret leak.
+- **Browser harness (`tests/stress_test.html`) is not in CI.** Node suite
+  covers the extractable functions; IDB/boot timings stay manual.
+- No `SECURITY.md` / `CODEOWNERS` / Dependabot (there are no npm deps).
+
+## Dead code / do not delete without a reason
+
+| Path | Verdict |
+|---|---|
+| `configurator.html` | Explicit archive. Keep in git; optional Pages drop (P2). |
+| `scripts/*.json` intermediates | Pipeline inputs. Unpublished (Pages comment). Keep. |
+| Duplicate `ARCHITECTURE.md` | Safe to collapse later. |
+| `demo/` gitignore entries | Safe to delete. |
+
+## What this PR changed (≤3 concrete fixes)
+
+1. Repair the OSPF ncclient snippet + snippet-syntax smoke test.
+2. Sync README vendor/category figures and gate the vendor table in
+   `check_consistency.py`.
+3. Correct `docs/assets/hero.svg` from 52,031 → 70,006.
+
+## Skipped (out of scope)
+
+- Regenerating `commands.json` or growing SONiC / SR OS.
+- Filling 945 empty descriptions.
+- Adding `deep_gap_dig.py` as a third CI job (already covered by Node).
+- Deleting `configurator.html` or merging the two architecture files.
+- Browser / Playwright coverage of `index.html` / `studio.html`.
+- Dependency upgrades (none broken; UI has zero npm).
+
+## Next recommended agent job
+
+Add a `--dry-run` / refuse-if-shrink guard to `scripts/parse.py` so a
+partial pipeline cannot silently overwrite the 70,006-row corpus.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ vendors and host/tool surfaces are tagged in the **Type** column.
 
 | Vendor / Tool | OS / Surface | Type | Commands |
 |---|---|---|---|
-| **Cisco** | IOS / IOS-XE (full **Master Command List**) · ASA 9.24 · NX-OS | Network | 22,145 |
+| **Cisco** | IOS / IOS-XE (full **Master Command List**) · ASA 9.24 · NX-OS | Network | 22,168 |
 | **Arista** | EOS | Network | 7,397 |
 | **VyOS** | VyOS (full config tree) | Network | 6,289 |
 | **Huawei** | VRP (bracketed prompts, iStack, Eth-Trunk, OSPF/BGP) | Network | 4,425 |
@@ -85,20 +85,20 @@ vendors and host/tool surfaces are tagged in the **Type** column.
 | **FRR** | FRRouting (vtysh) — docs **+ verified live on a 10-node Docker FRR lab** | Network | 3,949 |
 | **Microsoft** | Windows PowerShell networking cmdlets | Host OS | 3,352 |
 | **Juniper** | Junos (MX / EX / QFX / SRX) | Network | 3,217 |
-| **Extreme** | EXOS (VLAN-centric, STP, OSPF, SummitStacking, MLAG, ACLs) | Network | 2,790 |
+| **Extreme** | EXOS (VLAN-centric, STP, OSPF, SummitStacking, MLAG, ACLs) | Network | 2,800 |
 | **Linux** | `ip` / `iproute2` / host networking | Host OS | 2,592 |
 | **FortiOS** | Fortinet (`config / set / end` blocks, REST cmdb) | Network | 2,383 |
 | **Wireshark** | `tshark` capture + display filters | Tool | 2,130 |
 | **PAN-OS** | Palo Alto firewalls (`set rulebase security ...`, virtual routers) | Network | 1,224 |
 | **Mikrotik** | RouterOS (`/path` syntax, firewall filters, queues) | Network | 1,216 |
 | **NVIDIA** | Cumulus Linux 5.x with NVUE (`nv set/show`) | Network | 1,168 |
-| **Nokia** | SR Linux (declarative) **+ SR OS** (`os=sros`, classic CLI) | Network | 1,125 |
+| **Nokia** | SR Linux (declarative) **+ SR OS** (`os=sros`, classic CLI) | Network | 1,131 |
 | **SONiC** | OCP / Azure SONiC (Click CLI, `show ip ...`) | Network | 459 |
 | | | **TOTAL (17)** | **70,006** |
 
-By category (top 10): Interfaces 17,490 · Protocols 10,173 · System 7,815 ·
-Troubleshooting 6,513 · Security 4,369 · VLAN 4,208 · Routing 2,806 ·
-BGP 2,153 · Misc 2,018 · OSPF 1,604. Dedicated **VXLAN** (255) and **EVPN** (498) categories added.
+By category (top 10): Interfaces 16,941 · Protocols 10,150 · System 7,705 ·
+Troubleshooting 6,501 · Security 4,370 · VLAN 4,084 · Routing 2,793 ·
+BGP 2,155 · Misc 2,018 · OSPF 1,606. Dedicated **VXLAN** (257) and **EVPN** (499) categories added.
 
 Modern-ops coverage (new): Telemetry (gNMI/gRPC/NETCONF/RESTCONF) ·
 Automation (on-box Python/eAPI/JSON-RPC) · Provisioning (ZTP/PnP/POAP) ·

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -93,7 +93,7 @@ One-time repo setting (cannot be flipped via API): **Settings → Pages → Sour
 2. `parse.py` last without the fill scripts → corpus shrinks and CI fails.
 3. Missing `.nojekyll` → Pages build dies on Jinja.
 4. Full-repo Pages artifact → deploy timeout. Use the lean `_site/` workflow.
-5. Stale vendor tables in README that `check_consistency.py` does **not** gate (it only checks total / roles / vendor-count phrase). Recompute from `commands.json` when editing the table.
+5. Stale vendor tables in README. `check_consistency.py` now gates each README vendor-row count against `commands.json` (plus total / roles / “17 vendor”). Recompute from the corpus when editing the table.
 
 ## Open corpus work
 

--- a/docs/assets/hero.svg
+++ b/docs/assets/hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 360" role="img" aria-labelledby="heroTitle heroDesc" fill="none" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
   <title id="heroTitle">multivendor-cli-configurator — architecture</title>
-  <desc id="heroDesc">Animated terminal banner: a phosphor-green prompt types a network command while 17 vendor chips light up in sequence, connector lines pulse from the command to each matched vendor, a stream of grayed commands scrolls behind, and a counter ticks toward 52,031 commands.</desc>
+  <desc id="heroDesc">Animated terminal banner: a phosphor-green prompt types a network command while 17 vendor chips light up in sequence, connector lines pulse from the command to each matched vendor, a stream of grayed commands scrolls behind, and a counter ticks toward 70,006 commands.</desc>
 
   <defs>
     <!-- backgrounds -->
@@ -141,7 +141,7 @@
 
     <!-- live counter -->
     <text x="66" y="170" font-size="12" fill="#8b9a8e">corpus</text>
-    <text x="116" y="170" font-size="13" font-weight="700" fill="#39ff14" filter="url(#glow)">52,031 commands</text>
+    <text x="116" y="170" font-size="13" font-weight="700" fill="#39ff14" filter="url(#glow)">70,006 commands</text>
     <text x="290" y="170" font-size="11" fill="#5eead4">cache-then-revalidate</text>
   </g>
 

--- a/index.html
+++ b/index.html
@@ -2064,7 +2064,7 @@ const AUTO_OSPF = {
 </config>`,
     ncclient: `# OSPF process ${v.pid}, network ${v.net} ${v.wild} area ${v.area}
 from ncclient import manager
-m = manager.connect(host=${pyArg('host')}, port=port=830,, username=${pyArg('user')}, password=${pyArg('pass')},
+m = manager.connect(host=${pyArg('host')}, username=${pyArg('user')}, password=${pyArg('pass')},
                     hostkey_verify=False, device_params={"name":"iosxe"})
 m.edit_config(target="running", config=open("ospf.xml").read())`,
     ansible: `- name: OSPF process ${v.pid}

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -5,11 +5,13 @@ The command count, per-role breakdown, and vendor count are repeated by hand
 across README.md and docs/index.html. This checker recomputes them from the
 single source of truth (commands.json) and asserts every derived figure still
 appears verbatim in those files, so a stale number fails CI instead of shipping.
+The README vendor table is also checked row-by-row (docs/index.html has no
+per-vendor counts).
 
 Design notes:
 - Hard failures are the raw numeric facts (total count, per-role counts, vendor
-  count) — these are what actually drift and each is matched as a substring, so
-  surrounding wording can change freely without tripping CI.
+  count, and README per-vendor table cells) — totals/roles/vendor-count are
+  matched as a substring so surrounding wording can change freely.
 - The rounded marketing form (e.g. "69,000+") and the ~MB size are advisory
   warnings only, since those are phrasing/rounding choices that flip on small
   changes and shouldn't gate a merge.
@@ -20,6 +22,7 @@ Exit 0 = consistent, 1 = drift found (details printed), 2 = usage/IO error.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -79,6 +82,19 @@ def main() -> int:
         for value in required:
             if value not in text:
                 failures.append(f"{rel}: missing {value!r}")
+
+    # README vendor table is the only public per-vendor count surface.
+    # docs/index.html does not list per-vendor figures, so this is README-only.
+    # Match the markdown row: | **Vendor** | ... | N |
+    vendor_counts = Counter(row.get("vendor", "?") for row in data)
+    readme = contents.get("README.md")
+    if readme is not None:
+        for vendor, n in sorted(vendor_counts.items(), key=lambda kv: -kv[1]):
+            pat = rf"\| \*\*{re.escape(vendor)}\*\* \|[^|\n]+\|[^|\n]+\| {fmt(n)} \|"
+            if not re.search(pat, readme):
+                failures.append(
+                    f"README.md: vendor table missing {vendor} {fmt(n)}"
+                )
 
     # Advisory only — phrasing/rounding, not raw facts.
     for rel, text in contents.items():

--- a/tests/stress_test.js
+++ b/tests/stress_test.js
@@ -225,6 +225,25 @@ results['T6b_concept_correctness'] = `${conceptOK}/${conceptCases.length}`;
   results['T9_queue_vendors'] = queue.map(d => d.vendor);
 }
 
+// --- Snippet syntax smoke (catches copy-paste like port=port=830,,) --------
+{
+  let snippetFails = 0;
+  if (html.includes('port=port')) {
+    snippetFails++;
+    console.log('   SNIPPET MISS: port=port in index.html');
+  }
+  const connectLines = html.split('\n').filter(l => l.includes('manager.connect('));
+  for (const line of connectLines) {
+    if (/,\s*,/.test(line) || /=\s*=/.test(line)) {
+      snippetFails++;
+      console.log(`   SNIPPET MISS: ${line.trim().slice(0, 96)}`);
+    }
+  }
+  console.log(`Snippet connect lines: ${connectLines.length} scanned, ${snippetFails} malformed`);
+  if (snippetFails) failures += snippetFails;
+  results['snippet_connect_lines'] = { scanned: connectLines.length, malformed: snippetFails };
+}
+
 // --- Vendor coverage smoke check -------------------------------------------
 {
   const expected = ['Cisco','Juniper','Arista','FRR','VyOS','SONiC','NVIDIA','PAN-OS','Nokia','FortiOS','Mikrotik','Extreme','Aruba','Huawei','Microsoft','Linux','Wireshark'];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Ranked gap scan of the static 70,006-command cheatsheet + pipeline. Three small, safe fixes only. No corpus rewrite, no dependency upgrades, no new product features.

Details: [`GAP_ANALYSIS.md`](https://github.com/gesh75/multivendor-cli-configurator/blob/cursor/gap-scan-multivendor-cli-configurator-d2db/GAP_ANALYSIS.md)

## What I proved

- `python3 scripts/check_consistency.py` — totals/roles/`17 vendor` already matched; the **README vendor table did not** (Cisco 22,145 vs 22,168, Extreme 2,790 vs 2,800, Nokia 1,125 vs 1,131; table summed to 69,967).
- Negative proof: replaying the pre-fix cells fails the new vendor-row regex for exactly those three vendors.
- `python3 scripts/audit_data_quality.py` — 0 cmd-prose / title-prose / over-long titles.
- `python3 scripts/deep_gap_dig.py` — 0 critical; advisory 945 empty `desc` (VyOS 742, FRR 170).
- `python3 -m compileall scripts` — all parsers parse.
- `commands.json` — 70,006 rows, 17 vendors, 21 OS labels, 0 duplicate `(vendor, cmd)`, 0 empty title/cmd.
- `index.html` Cisco `AUTO_OSPF` ncclient template contained `port=port=830,,` (copy-paste `SyntaxError`). Sibling templates do not.
- `node tests/stress_test.js` — **ALL TESTS PASSED** after the fixes (32 `manager.connect(` lines scanned, 0 malformed).
- GitHub Actions `ci.yml` is green on this PR. Buildkite `pull_request` fails in ~2s with **no in-repo pipeline** (same on merged PR #13; `main` build #11 passed) — recorded as P1, not caused by these diffs.

## Fixes in this PR (3)

1. **Correctness** — drop the broken `port=port=830,,` fragment; add a Node smoke check on `manager.connect(` lines.
2. **Docs + CI** — sync README vendor/category figures; `check_consistency.py` now regex-gates each README vendor-row count.
3. **Docs** — `docs/assets/hero.svg` 52,031 → 70,006.

## What I skipped

- Regenerating or growing the corpus (SONiC / SR OS floors).
- Filling 945 empty descriptions.
- Wiring `deep_gap_dig.py` as a third CI job (Node suite already covers the floors).
- Deleting `configurator.html` or collapsing the duplicate `ARCHITECTURE.md` pair.
- Browser/Playwright coverage of the cheatsheet or Studio.
- Fixing or adding a Buildkite pipeline (external; GHA is the real gate).
- A `--dry-run` / refuse-if-shrink guard on `scripts/parse.py` (called out as the next job).

## Next recommended agent job

Add a `--dry-run` / refuse-if-shrink guard to `scripts/parse.py` so a partial pipeline cannot silently overwrite the 70,006-row corpus.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91a2bebc-cab7-4364-9dcc-349ce226c2e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91a2bebc-cab7-4364-9dcc-349ce226c2e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Audit the cheatsheet and pipeline for consistency gaps, then correct stale public metrics and a copy-paste-breaking automation example.

Bug Fixes:
- Fix the malformed Cisco OSPF ncclient automation snippet and add smoke coverage to catch malformed connection calls.

Enhancements:
- Add row-level validation for README vendor counts against the command corpus.
- Document the repository’s verified data-quality findings and prioritized follow-up work.

Documentation:
- Synchronize README vendor and category statistics with the 70,006-command corpus.
- Update the documentation hero artwork to display the current command count.

Tests:
- Extend the Node stress suite with automated snippet syntax checks.